### PR TITLE
update metadata codegen

### DIFF
--- a/generate/src/generateCode.scala
+++ b/generate/src/generateCode.scala
@@ -206,7 +206,7 @@ def templateCode(
     |
     |${code}
     |    metrics = json.dumps(result.metadata_details, indent=2)
-    |    metadata = json.dumps(json.loads(result.datadoc), indent=2)
+    |    metadata = result.datadoc
     |    logging.info("Metrics metadata %s", metrics)
     |    final_df = result.to_polars()
 

--- a/schema-validation/test/data/golden/process_shared_data1.py
+++ b/schema-validation/test/data/golden/process_shared_data1.py
@@ -114,7 +114,7 @@ def main(file_path):
         .run()
     )
     metrics = json.dumps(result.metadata_details, indent=2)
-    metadata = json.dumps(json.loads(result.datadoc), indent=2)
+    metadata = result.datadoc
     logging.info("Metrics metadata %s", metrics)
     final_df = result.to_polars()
 

--- a/schema-validation/test/data/golden/process_shared_data2.py
+++ b/schema-validation/test/data/golden/process_shared_data2.py
@@ -103,7 +103,7 @@ def main(file_path):
 
     result = build_and_run_depseudo(df,datadoc,["fnr","fnr_naa"])
     metrics = json.dumps(result.metadata_details, indent=2)
-    metadata = json.dumps(json.loads(result.datadoc), indent=2)
+    metadata = result.datadoc
     logging.info("Metrics metadata %s", metrics)
     final_df = result.to_polars()
 


### PR DESCRIPTION
When the new `dapla-toolbelt-pseudo` release is ready indentation will automatically be added in output string of `result.datadoc`.

ONLY merge when the new release (`v6.0.1`) of  `dapla-toolbelt-pseudo` is ready and added to the docker image for delomaten.